### PR TITLE
Remove dependency on hard-coded file location in `Configuration` class

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
+# NOTE: debugging is enabled and optimization is disabled
 GPP = g++ -g -Wall -Wextra -std=c++11
+
 UTILS = ../../Utilities
 SCANNER = ../../Utilities
 SCANLINE = ../../Utilities

--- a/mydirectory/group7_hw7/configuration.cc
+++ b/mydirectory/group7_hw7/configuration.cc
@@ -32,7 +32,7 @@ int Configuration::GetMaxServiceSubscript() const {
 **/
 /****************************************************************
 **/
-void Configuration::ReadConfiguration(Scanner& instream) {
+void Configuration::ReadConfiguration(Scanner& instream, Scanner& data_stream) {
   /*
   */
   string line;
@@ -57,11 +57,8 @@ void Configuration::ReadConfiguration(Scanner& instream) {
     arrival_fractions_.push_back(input);
   }
 
-  Scanner service_times_file;
-  // TODO(hxtk): document or remove hard-coded filename
-  service_times_file.OpenFile("../../dataallsorted.txt");
-  while (service_times_file.HasNext()) {
-    int thetime = service_times_file.NextInt();
+  while (data_stream.HasNext()) {
+    int thetime = data_stream.NextInt();
     actual_service_times_.push_back(thetime);
   }
 }

--- a/mydirectory/group7_hw7/configuration.h
+++ b/mydirectory/group7_hw7/configuration.h
@@ -55,7 +55,7 @@ class Configuration {
   **/
 
   int GetMaxServiceSubscript() const;
-  void ReadConfiguration(Scanner& instream);
+  void ReadConfiguration(Scanner& instream, Scanner& data_stream);
   string ToString();
 
  private:

--- a/mydirectory/group7_hw7/main.cc
+++ b/mydirectory/group7_hw7/main.cc
@@ -10,8 +10,9 @@
 static const string kTag = "MAIN: ";
 
 int main(int argc, char *argv[]) {
-  string config_filename;
+  string config_filename = "XX";
   string pct_filename = "XX";
+  string data_filename = "XX";
   string log_filename = "XX";
   string out_filename = "XX";
   string outstring = "XX";
@@ -21,6 +22,7 @@ int main(int argc, char *argv[]) {
 
   Scanner config_stream;
   Scanner pct_stream;
+  Scanner data_stream;
 
   Configuration config;
   Simulation simulation;
@@ -29,12 +31,15 @@ int main(int argc, char *argv[]) {
 
   cout << kTag << "Beginning execution" << endl;
 
-  Utils::CheckArgs(4, argc, argv,
-                   "configfilename pctfilename outfilename logfilename");
+  Utils::CheckArgs(
+      5, argc, argv,
+      "configfilename pctfilename datafilename outfilename logfilename");
+  
   config_filename = static_cast<string>(argv[1]);
   pct_filename = static_cast<string>(argv[2]);
-  out_filename = static_cast<string>(argv[3]);
-  log_filename = static_cast<string>(argv[4]);
+  data_filename = static_cast<string>(argv[3]);
+  out_filename = static_cast<string>(argv[4]);
+  log_filename = static_cast<string>(argv[5]);
 
   Utils::FileOpen(out_stream, out_filename);
   Utils::LogFileOpen(log_filename);
@@ -53,8 +58,10 @@ int main(int argc, char *argv[]) {
   // config has RN seed, station count spread, election day length
   //   and mean and dev voting time
   config_stream.OpenFile(config_filename);
-  config.ReadConfiguration(config_stream);
+  data_stream.OpenFile(data_filename);
+  config.ReadConfiguration(config_stream, data_stream);
   config_stream.Close();
+  data_stream.Close();
 
   outstring = kTag + config.ToString() + "\n";
   out_stream << outstring << endl;

--- a/mydirectory/group7_hw7/onepct.cc
+++ b/mydirectory/group7_hw7/onepct.cc
@@ -98,7 +98,7 @@ void OnePct::CreateVoters(const Configuration& config, MyRandom& random,
 
     int arrival = hour * 3600;
     for (int voter = 0; voter < voters_this_hour; ++voter) {
-      double lambda = static_cast<double>(voters_this_hour / 3600.0);
+      double lambda = static_cast<double>(voters_this_hour) / 3600.0;
       int interarrival = random.RandomExponentialInt(lambda);
       arrival += interarrival;
       int durationsub =

--- a/mydirectory/group7_hw7/onepct.cc
+++ b/mydirectory/group7_hw7/onepct.cc
@@ -98,7 +98,7 @@ void OnePct::CreateVoters(const Configuration& config, MyRandom& random,
 
     int arrival = hour * 3600;
     for (int voter = 0; voter < voters_this_hour; ++voter) {
-      double lambda = static_cast<double>(voters_this_hour) / 3600.0;
+      double lambda = static_cast<double>(voters_this_hour / 3600.0);
       int interarrival = random.RandomExponentialInt(lambda);
       arrival += interarrival;
       int durationsub =

--- a/zdExecuteScript.txt
+++ b/zdExecuteScript.txt
@@ -7,7 +7,7 @@ do
   echo " "
   echo "EXECUTING" $item
   cd $item
-  ./Aprog ../../xconfig100zero.txt ../../xpctfile.txt zzout zzlog >zzstdout0013
+  ./Aprog ../../xconfig100zero.txt ../../xpctfile.txt ../../dataallsorted.txt zzout zzlog >zzstdout0013
   cd ..
 echo "EXECUTION COMPLETE"
 done


### PR DESCRIPTION
The `Configuration` class currently depends upon a hard-coded file location to read the data. In this patch, I have made it so that the data file path is passed in as the 3rd command line argument.

I have also altered the `entry point` to open and close this stream and pass it into the relevant function call.

Finally, `zdExecuteScript.txt` has been altered to pass in this new argument.